### PR TITLE
Scale dummy webserver during ACME renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ The detailed steps of setting this up are:
             - `CERT_SECRET_NAME` -> <create a name for your secret holding the TLS certificate>
             - `INGRESS_NAME` -> `<your ingress name>` (e.g. `site-ig`)
             - `WEB_ROOT` -> `<path to web root>` (e.g. `/ssl/www` if that's the root directory served by your web server),
-            - `DUMMY_WEBSERVER` -> `<Work load name from step 1>` (e.g. `dummy-websrv`)
+            - `DUMMY_WEBSERVER` -> `<dummy web server Service name>` (e.g. `dummy-websrv`). This must be the Service name used by the Ingress backend, not necessarily the Deployment/workload name.
         * Optional environment variables:
-            - `DUMMY_WEBSERVER_DEPLOYMENT` -> deployment name for the dummy web server if it differs from `DUMMY_WEBSERVER`;
-            - `DUMMY_WEBSERVER_SCALE_REPLICAS` -> number of replicas to use when temporarily scaling up a dummy web server that is currently at `0` replicas; defaults to `1`;
+            - `DUMMY_WEBSERVER_DEPLOYMENT` -> deployment name for the dummy web server to scale if it differs from the `DUMMY_WEBSERVER` Service name; if the Service and Deployment have the same name, you can omit this variable;
+            - `DUMMY_WEBSERVER_SCALE_REPLICAS` -> number of replicas to use when temporarily scaling up a dummy web server deployment that is currently at `0` replicas; defaults to `1`;
             - `DUMMY_WEBSERVER_READY_TIMEOUT` -> rollout wait timeout for the dummy web server deployment; defaults to `60s`.
     - Click "Save"
 4. Once the Cronjob is configured, you can trigger a run by hand, and verify it the settings are correct.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ The detailed steps of setting this up are:
             - `INGRESS_NAME` -> `<your ingress name>` (e.g. `site-ig`)
             - `WEB_ROOT` -> `<path to web root>` (e.g. `/ssl/www` if that's the root directory served by your web server),
             - `DUMMY_WEBSERVER` -> `<Work load name from step 1>` (e.g. `dummy-websrv`)
+        * Optional environment variables:
+            - `DUMMY_WEBSERVER_DEPLOYMENT` -> deployment name for the dummy web server if it differs from `DUMMY_WEBSERVER`;
+            - `DUMMY_WEBSERVER_SCALE_REPLICAS` -> number of replicas to use when temporarily scaling up a dummy web server that is currently at `0` replicas; defaults to `1`;
+            - `DUMMY_WEBSERVER_READY_TIMEOUT` -> rollout wait timeout for the dummy web server deployment; defaults to `60s`.
     - Click "Save"
 4. Once the Cronjob is configured, you can trigger a run by hand, and verify it the settings are correct.
     - In the Workload -> Cronjobs window, click the three dots on the the right side of the page for the newly configured Cronjob, click "Run Now";
@@ -95,6 +99,7 @@ The detailed steps of setting this up are:
 
 1. This can be applied when there are multiple web servers in the same namespace. Every web server will need an Ingress controller, and a Cronjob for renewing the TLS certificate.
 2. The Ingress controller created by the script in Case 2 can be freely modified later if real web server is added in the namespace. It will not be overwritten but preserved during future runs of the Cronjob.
+3. For Case 2, the dummy web server deployment can normally be scaled to `0`. The renewal script records the deployment's original replica count, scales it up only when needed, waits for the rollout to become available, and scales it back to `0` at the end if it started at `0`.
 
 ## Using `kubectl`
 
@@ -216,4 +221,3 @@ Fill in `<secret name>` and `<path to kubeconfig file>` accordingly.
 
 
 ### Create a Cronjob
-

--- a/get_cert_update_ssl.sh
+++ b/get_cert_update_ssl.sh
@@ -77,6 +77,11 @@ DUMMY_WEBSERVER_READY_TIMEOUT=${DUMMY_WEBSERVER_READY_TIMEOUT:-60s}
 SCALED_DUMMY_WEBSERVER=false
 ORIGINAL_DUMMY_WEBSERVER_REPLICAS=""
 
+if ! [[ "${DUMMY_WEBSERVER_SCALE_REPLICAS}" =~ ^[1-9][0-9]*$ ]]; then
+	echo "Error: DUMMY_WEBSERVER_SCALE_REPLICAS must be an integer greater than or equal to 1. Current value: ${DUMMY_WEBSERVER_SCALE_REPLICAS}"
+	exit 1
+fi
+
 trap cleanup EXIT
 
 if [[ $USER_DOMAIN_LIST == *:* ]]; then

--- a/get_cert_update_ssl.sh
+++ b/get_cert_update_ssl.sh
@@ -27,7 +27,7 @@ cleanup() {
 ensure_dummy_webserver_ready() {
 	if ! /opt/kubectl get deployment -n "${NAMESPACE}" "${DUMMY_WEBSERVER_DEPLOYMENT}" >/dev/null 2>&1; then
 		echo "Error: dummy webserver deployment ${DUMMY_WEBSERVER_DEPLOYMENT} was not found in namespace ${NAMESPACE}."
-		echo "Error: set DUMMY_WEBSERVER_DEPLOYMENT if the deployment name differs from DUMMY_WEBSERVER."
+		echo "Error: DUMMY_WEBSERVER_DEPLOYMENT controls the Kubernetes Deployment name checked here; DUMMY_WEBSERVER is the dummy webserver Service / Ingress backend name. Set DUMMY_WEBSERVER_DEPLOYMENT if the Deployment name differs from the Service name."
 		exit 1
 	fi
 

--- a/get_cert_update_ssl.sh
+++ b/get_cert_update_ssl.sh
@@ -15,7 +15,10 @@ restore_existing_ingress() {
 scale_down_dummy_webserver_if_needed() {
 	if [ "${SCALED_DUMMY_WEBSERVER:-false}" = "true" ] && [ "${ORIGINAL_DUMMY_WEBSERVER_REPLICAS:-}" = "0" ]; then
 		echo "Info: scaling dummy webserver deployment ${DUMMY_WEBSERVER_DEPLOYMENT} back to 0 replicas"
-		/opt/kubectl -n "${NAMESPACE}" scale deployment "${DUMMY_WEBSERVER_DEPLOYMENT}" --replicas=0
+		if ! /opt/kubectl -n "${NAMESPACE}" scale deployment "${DUMMY_WEBSERVER_DEPLOYMENT}" --replicas=0; then
+			echo "Error: failed to scale dummy webserver deployment ${DUMMY_WEBSERVER_DEPLOYMENT} back to 0 replicas."
+			exit 1
+		fi
 	fi
 }
 

--- a/get_cert_update_ssl.sh
+++ b/get_cert_update_ssl.sh
@@ -12,6 +12,48 @@ restore_existing_ingress() {
 	fi
 }
 
+scale_down_dummy_webserver_if_needed() {
+	if [ "${SCALED_DUMMY_WEBSERVER:-false}" = "true" ] && [ "${ORIGINAL_DUMMY_WEBSERVER_REPLICAS:-}" = "0" ]; then
+		echo "Info: scaling dummy webserver deployment ${DUMMY_WEBSERVER_DEPLOYMENT} back to 0 replicas"
+		/opt/kubectl -n "${NAMESPACE}" scale deployment "${DUMMY_WEBSERVER_DEPLOYMENT}" --replicas=0
+	fi
+}
+
+cleanup() {
+	restore_existing_ingress
+	scale_down_dummy_webserver_if_needed
+}
+
+ensure_dummy_webserver_ready() {
+	if ! /opt/kubectl get deployment -n "${NAMESPACE}" "${DUMMY_WEBSERVER_DEPLOYMENT}" >/dev/null 2>&1; then
+		echo "Error: dummy webserver deployment ${DUMMY_WEBSERVER_DEPLOYMENT} was not found in namespace ${NAMESPACE}."
+		echo "Error: set DUMMY_WEBSERVER_DEPLOYMENT if the deployment name differs from DUMMY_WEBSERVER."
+		exit 1
+	fi
+
+	ORIGINAL_DUMMY_WEBSERVER_REPLICAS=$(/opt/kubectl get deployment -n "${NAMESPACE}" "${DUMMY_WEBSERVER_DEPLOYMENT}" -o jsonpath='{.spec.replicas}')
+	if [ -z "${ORIGINAL_DUMMY_WEBSERVER_REPLICAS}" ]; then
+		ORIGINAL_DUMMY_WEBSERVER_REPLICAS=1
+	fi
+
+	if [ "${ORIGINAL_DUMMY_WEBSERVER_REPLICAS}" = "0" ]; then
+		echo "Info: dummy webserver deployment ${DUMMY_WEBSERVER_DEPLOYMENT} is scaled to 0; scaling to ${DUMMY_WEBSERVER_SCALE_REPLICAS}"
+		if ! /opt/kubectl -n "${NAMESPACE}" scale deployment "${DUMMY_WEBSERVER_DEPLOYMENT}" --replicas="${DUMMY_WEBSERVER_SCALE_REPLICAS}"; then
+			echo "Error: failed to scale dummy webserver deployment ${DUMMY_WEBSERVER_DEPLOYMENT}."
+			exit 1
+		fi
+		SCALED_DUMMY_WEBSERVER=true
+	else
+		echo "Info: dummy webserver deployment ${DUMMY_WEBSERVER_DEPLOYMENT} already has ${ORIGINAL_DUMMY_WEBSERVER_REPLICAS} replicas configured."
+	fi
+
+	echo "Info: waiting for dummy webserver deployment ${DUMMY_WEBSERVER_DEPLOYMENT} to become available"
+	if ! /opt/kubectl -n "${NAMESPACE}" rollout status deployment "${DUMMY_WEBSERVER_DEPLOYMENT}" --timeout="${DUMMY_WEBSERVER_READY_TIMEOUT}"; then
+		echo "Error: dummy webserver deployment ${DUMMY_WEBSERVER_DEPLOYMENT} did not become ready within ${DUMMY_WEBSERVER_READY_TIMEOUT}."
+		exit 1
+	fi
+}
+
 check_env_variable "EMAIL"
 check_env_variable "DOMAIN"
 check_env_variable "KUBECONFIG"
@@ -26,6 +68,13 @@ CLUSTER=$(/opt/kubectl config current-context)
 FIRST_DOMAIN=$(echo $DOMAIN | cut -d':' -f1)
 USER_DOMAIN_LIST=$DOMAIN
 SPIN_DOMAIN=$INGRESS_NAME.$NAMESPACE.${CLUSTER}.svc.spin.nersc.org
+DUMMY_WEBSERVER_DEPLOYMENT=${DUMMY_WEBSERVER_DEPLOYMENT:-$DUMMY_WEBSERVER}
+DUMMY_WEBSERVER_SCALE_REPLICAS=${DUMMY_WEBSERVER_SCALE_REPLICAS:-1}
+DUMMY_WEBSERVER_READY_TIMEOUT=${DUMMY_WEBSERVER_READY_TIMEOUT:-60s}
+SCALED_DUMMY_WEBSERVER=false
+ORIGINAL_DUMMY_WEBSERVER_REPLICAS=""
+
+trap cleanup EXIT
 
 if [[ $USER_DOMAIN_LIST == *:* ]]; then
 	IFS=':' read -ra DOMAIN_ARRAY <<< "$USER_DOMAIN_LIST"
@@ -64,6 +113,8 @@ cat <<EOF >> /tmp/ssl_ingress.yaml
 EOF
 done
 
+ensure_dummy_webserver_ready
+
 # Backup existing ingress
 # Check if ingress controller exists
 if ! /opt/kubectl get ingress -n ${NAMESPACE} ${INGRESS_NAME} >/dev/null 2>&1; then
@@ -83,7 +134,10 @@ else
 fi
 
 # Apply new ingress for issuing TLS certificate
-/opt/kubectl apply -f /tmp/ssl_ingress.yaml
+if ! /opt/kubectl apply -f /tmp/ssl_ingress.yaml; then
+	echo "Error: failed to apply temporary ingress for issuing TLS certificate."
+	exit 1
+fi
 
 echo "sleep for 10s for the ingress change to propagate"
 sleep 10
@@ -98,7 +152,6 @@ for domain in "${DOMAIN_ARRAY[@]}"; do
 		echo "Error: Please make sure the domain is correct and accessible."
 		echo "Error: If the domain is correct, please make sure you wait enough time for the DNS to reflect the change."
 		echo "Error: you can use 'dig +short $domain' to check the IP address of the domain."
-		restore_existing_ingress
 		exit 1
 	fi
 	ACME_DOMAINS+=" -d $domain"
@@ -116,7 +169,6 @@ ACME_HOME=/tmp/acme
 # exit 1 if the previous command fails
 if [ $? -ne 0 ]; then
 	echo "Error: obtaining certificate from Let's Encrypt failed."
-	restore_existing_ingress
 	exit 1
 fi
 
@@ -134,9 +186,5 @@ if [[ -f $CERT_PATH && -f $KEY_PATH ]]; then
 		/opt/kubectl apply -f -
 else
 	echo "Error: $CERT_PATH or $KEY_PATH does not exist."
-	restore_existing_ingress
 	exit 1
 fi
-
-# Restore ingress if it exists
-restore_existing_ingress


### PR DESCRIPTION
## Summary
- scale the dummy webserver deployment up only when it was at 0 replicas
- wait for the dummy webserver rollout before swapping ingress for ACME HTTP-01
- restore the ingress and scale the dummy webserver back to 0 on exit when it started at 0
- document optional tuning environment variables

## Validation
- bash -n get_cert_update_ssl.sh get_cert_update_ssl_with_websrv.sh
- git diff --check