### PR TITLE
Address PR 6 Copilot suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In this case, you will need to create a deployment running a simple web server, 
     - download the configuration in JSON format;
     - use `jq` to remove volatile Kubernetes metadata/status while preserving
       labels and useful annotations;
-    - save the output into a JSON file, ready to be be reapplied via `kubectl`;
+    - save the output into a JSON file, ready to be reapplied via `kubectl`;
 2. prepare a YAML file to configure the ingress for the user-facing domains specified in the `$DOMAIN` environment variable, and also add the auto-created `*.svc.spin.nersc.org` hostname internally for ingress access; the certificate request still excludes that internal hostname;
 3. apply the newly prepared ingress via `kubectl` and temporarily remove the
    `nginx.ingress.kubernetes.io/whitelist-source-range` annotation, if present,

--- a/get_cert_update_ssl.sh
+++ b/get_cert_update_ssl.sh
@@ -43,14 +43,34 @@ restore_existing_ingress_annotations() {
 
 remove_temporary_ingress_annotations() {
 	local annotations
+	local annotation_present
+	local ingress_json
 	annotations=${TEMP_INGRESS_REMOVE_ANNOTATIONS:-nginx.ingress.kubernetes.io/whitelist-source-range}
 
 	for annotation in ${annotations//,/ }; do
 		if [ -z "$annotation" ]; then
 			continue
 		fi
+
+		if ! ingress_json=$(/opt/kubectl -n "${NAMESPACE}" get ingress "${INGRESS_NAME}" -o json); then
+			echo "Error: failed to read ingress ${INGRESS_NAME} before removing temporary annotations."
+			return 1
+		fi
+
+		if ! annotation_present=$(printf '%s' "${ingress_json}" | jq -e --arg annotation "$annotation" '.metadata.annotations // {} | has($annotation)'); then
+			if [ "${annotation_present}" = "false" ]; then
+				echo "Info: ingress annotation ${annotation} is not present on ${INGRESS_NAME}; nothing to remove"
+				continue
+			fi
+			echo "Error: failed to check ingress annotation ${annotation} on ${INGRESS_NAME}."
+			return 1
+		fi
+
 		echo "Info: temporarily removing ingress annotation ${annotation} from ${INGRESS_NAME}"
-		/opt/kubectl -n "${NAMESPACE}" annotate ingress "${INGRESS_NAME}" "${annotation}-" >/dev/null 2>&1 || true
+		if ! /opt/kubectl -n "${NAMESPACE}" annotate ingress "${INGRESS_NAME}" "${annotation}-"; then
+			echo "Error: failed to temporarily remove ingress annotation ${annotation} from ${INGRESS_NAME}."
+			return 1
+		fi
 	done
 }
 
@@ -59,14 +79,23 @@ scale_down_dummy_webserver_if_needed() {
 		echo "Info: scaling dummy webserver deployment ${DUMMY_WEBSERVER_DEPLOYMENT} back to 0 replicas"
 		if ! /opt/kubectl -n "${NAMESPACE}" scale deployment "${DUMMY_WEBSERVER_DEPLOYMENT}" --replicas=0; then
 			echo "Error: failed to scale dummy webserver deployment ${DUMMY_WEBSERVER_DEPLOYMENT} back to 0 replicas."
-			exit 1
+			return 1
 		fi
 	fi
 }
 
 cleanup() {
-	restore_existing_ingress
-	scale_down_dummy_webserver_if_needed
+	local exit_code=$?
+
+	if ! restore_existing_ingress; then
+		exit_code=1
+	fi
+
+	if ! scale_down_dummy_webserver_if_needed; then
+		exit_code=1
+	fi
+
+	exit "${exit_code}"
 }
 
 ensure_dummy_webserver_ready() {
@@ -188,7 +217,9 @@ if ! /opt/kubectl apply -f /tmp/ssl_ingress.yaml; then
 	echo "Error: failed to apply temporary ingress for issuing TLS certificate."
 	exit 1
 fi
-remove_temporary_ingress_annotations
+if ! remove_temporary_ingress_annotations; then
+	exit 1
+fi
 
 echo "sleep for 10s for the ingress change to propagate"
 sleep 10


### PR DESCRIPTION
## Summary

Addresses the unresolved Copilot review suggestions from #6.

- Preserve cleanup failure reporting by making the EXIT trap return a failing status when ingress restore or dummy webserver scale-down fails.
- Make temporary ingress annotation removal fail fast on Kubernetes/API errors while still skipping annotations that are already absent.
- Fix the README typo in the ingress backup description.

## Impact

Failures during ingress restoration or temporary annotation removal now surface directly instead of allowing the ACME renewal workflow to continue or exit successfully with a hidden cleanup failure.

## Validation

- \
- \
- \